### PR TITLE
Add order state enum

### DIFF
--- a/Samples/Orchestrator/README.md
+++ b/Samples/Orchestrator/README.md
@@ -50,3 +50,15 @@ Samples.Orchestrator/
 ├── Program.cs
 ├── Samples.Orchestrator.http
 └── Properties/
+
+## Estados do Fluxo
+
+A máquina de estados trabalha com os seguintes passos:
+
+- `payment-submitted`
+- `payment-accepted`
+- `payment-cancelled`
+- `payment-rollback`
+- `shipping-submitted`
+- `shipping-accepted`
+

--- a/Samples/Orchestrator/Samples.Orchestrator.Core/Domain/States/OrderStatus.cs
+++ b/Samples/Orchestrator/Samples.Orchestrator.Core/Domain/States/OrderStatus.cs
@@ -1,0 +1,14 @@
+namespace Samples.Orchestrator.Core.Domain.States;
+
+/// <summary>
+/// Representa os possíveis estados do fluxo de orquestração.
+/// </summary>
+public enum OrderStatus
+{
+    PaymentSubmitted,
+    PaymentAccepted,
+    PaymentCancelled,
+    PaymentRollback,
+    ShippingSubmitted,
+    ShippingAccepted
+}


### PR DESCRIPTION
## Summary
- add enumeration of orchestrator states
- document the state flow in orchestrator README

## Testing
- `dotnet test Samples/Samples.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68439f1b80fc8333ab89e13d4a7018dc