### PR TITLE
Fix DI extension name

### DIFF
--- a/Samples/Orchestrator/Samples.Orchestrator.Core/Infrastructure/Extensions/DependencyInjectionExtensions.cs
+++ b/Samples/Orchestrator/Samples.Orchestrator.Core/Infrastructure/Extensions/DependencyInjectionExtensions.cs
@@ -4,10 +4,10 @@ namespace Samples.Orchestrator.Core.Infrastructure.Extensions;
 
 public static class DependencyInjectionExtensions
 {
-    public static IServiceCollection AddBDependencyInjection(this IServiceCollection services, IConfiguration configuration)
+    public static IServiceCollection AddDependencyInjection(this IServiceCollection services, IConfiguration configuration)
     {
         services.AddSingleton<IBrokerSettingsFactory, BrokerSettingsFactory>();
-        
+
         return services;
     }
 }

--- a/Samples/Orchestrator/Samples.Orchestrator.Core/Program.cs
+++ b/Samples/Orchestrator/Samples.Orchestrator.Core/Program.cs
@@ -12,7 +12,7 @@ builder.Services.AddSwaggerGen();
 
 builder.Services.AddMasstransit(builder.Configuration);
 builder.Services.AddEntityFramework(builder.Configuration);
-builder.Services.AddBDependencyInjection(builder.Configuration);
+builder.Services.AddDependencyInjection(builder.Configuration);
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- fix typo in DI extension method
- use the correct name in Program.cs

## Testing
- `dotnet test Samples/Orchestrator/Samples.Orchestrator.Tests/Samples.Orchestrator.Tests.csproj` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68439e157c0883339aeee942785e886f